### PR TITLE
Fix resizing of the snapshot view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Fix resizing of the snapshot view (Credits go to https://github.com/alienlebarge)
+
 ## 0.4.0
 
 - Redesigned UI some more (Credits go to https://github.com/Gaserd)

--- a/webdebugger/src/components/snapshot.css
+++ b/webdebugger/src/components/snapshot.css
@@ -3,7 +3,7 @@
   vertical-align: top;
   flex-grow: 1;
   margin-left: 26px;
-  overflow: scroll;
+  max-width: calc(100% - 26px)
 }
 
 .snapshot__basename {

--- a/webdebugger/src/components/snapshot.css
+++ b/webdebugger/src/components/snapshot.css
@@ -3,6 +3,7 @@
   vertical-align: top;
   flex-grow: 1;
   margin-left: 26px;
+  overflow: scroll;
 }
 
 .snapshot__basename {

--- a/webdebugger/src/components/snapshot.css
+++ b/webdebugger/src/components/snapshot.css
@@ -3,7 +3,7 @@
   vertical-align: top;
   flex-grow: 1;
   margin-left: 26px;
-  max-width: calc(100% - 26px)
+  max-width: calc(95% - 350px - 26px - 20px); /* article width - article padding - right col width - right col margin */
 }
 
 .snapshot__basename {


### PR DESCRIPTION
Corrects resizing the snapshots_view if CSS lines are longer than the width of the container.

In my CSS, I have big lines of CSS (due to base64 images).

``` css
.c-form-control-x input:checked ~ .c-form-control__indicator {
    background-image: url(data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4NCjwhLS0gR2VuZXJhdG9yOiBBZG9iZSBJbGx1c3RyYXRvciAxNy4xLjAsIFNWRyBFeHBvcnQgUGx1Zy1JbiAuIFNWRyBWZXJzaW9uOiA2LjAwIEJ1aWxkIDApICAtLT4NCjwhRE9DVFlQRSBzdmcgUFVCTElDICItLy9XM0MvL0RURCBTVkcgMS4xLy9FTiIgImh0dHA6Ly93d3cudzMub3JnL0dyYXBoaWNzL1NWRy8xLjEvRFREL3N2ZzExLmR0ZCI+DQo8c3ZnIHZlcnNpb249IjEuMSIgaWQ9IkxheWVyXzEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgeG1sbnM6eGxpbms9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkveGxpbmsiIHg9IjBweCIgeT0iMHB4Ig0KCSB3aWR0aD0iOHB4IiBoZWlnaHQ9IjhweCIgdmlld0JveD0iMCAwIDggOCIgZW5hYmxlLWJhY2tncm91bmQ9Im5ldyAwIDAgOCA4IiB4bWw6c3BhY2U9InByZXNlcnZlIj4NCjxwYXRoIGZpbGw9IiNGRkZGRkYiIGQ9Ik0xLjQsMEwwLDEuNGwwLjcsMC43bDEuOCwxLjhMMC43LDUuN0wwLDYuNGwxLjQsMS40bDAuNy0wLjdsMS44LTEuOGwxLjgsMS44bDAuNywwLjdsMS40LTEuNEw3LjEsNS43DQoJTDUuMywzLjlsMS44LTEuOGwwLjctMC43TDYuNCwwTDUuNywwLjdMMy45LDIuNUwyLjEsMC43QzIuMSwwLjcsMS40LDAsMS40LDB6Ii8+DQo8L3N2Zz4NCg==)
}
```

Here's what the change do:

![2016-09-13 08_40_41](https://cloud.githubusercontent.com/assets/611234/18464748/319a13e0-7993-11e6-93e8-eb1210dfbacf.gif)
